### PR TITLE
Fix points_to_gesture output

### DIFF
--- a/addons/swipe-detector/swipe_detector.gd
+++ b/addons/swipe-detector/swipe_detector.gd
@@ -263,8 +263,8 @@ func set_distance_threshold(value):
   distance_threshold = value
   return self
 
-func points_to_gesture(points):
-  return SwipeGesture.new(points)
+func points_to_gesture(points, area=null):
+  return SwipeGesture.new(area, points)
 
 
 


### PR DESCRIPTION
The constructor of SwipeGesture expects input in the form (area, points). Giving input in the form (points) as done in points_to_gesture crashes the game on any gesture recognition attempt due to points being empty.